### PR TITLE
Recursion limit

### DIFF
--- a/broken-link-check.py
+++ b/broken-link-check.py
@@ -43,60 +43,74 @@ def validate_json_file(file_path):
     else:
         raise ValueError("Unsupported file type. Please select a JSON file.")
 
-def copy_and_write_broken_link(link, url):
+def record_broken_link(link, url, error, origin_url=None, origin_file=None):
     """
-    Checks if the url key in link is an object. If so, create a deepcopy and modify the url key
-    to just include the broken link and append to broken_links.json. Else, just append to
-    broken_links.json
+    Appends a broken link entry to broken_links with original file/url context and error details.
 
-    Args: 
-        link (dictionary): dictionary object containing key value pairs ('url': 'www.theurl.com'
-        or 'url': {'en': 'www.theurl.com', 'es': 'www.theurl.com/es'}) that need to be tested.
+    Args:
+        link (dict): The link object being checked.
+        url (str): The actual URL that failed.
+        error (str): The error message or status.
+        origin_url (str, optional): The original URL from the source data.
+        origin_file (str, optional): The original file from the source data.
 
-    Returns: 
-        None, writes link object to broken_links
+    Returns:
+        None, appends broken links and their respective information as a dictionary to the broken_links array
     """
-    if isinstance(link['url'], dict): #create and modify a copy
-        copy_link = deepcopy(link)
-        copy_link['url'] = url #only include broken link
-        broken_links.append(copy_link)
-    else:
-        broken_links.append(link)
+    broken = {
+        "file": origin_file or link.get("file"),
+        "url": origin_url or url,
+        "Error": error,
+    }
+    if (origin_url and origin_url != url) or (not origin_url and link.get("url") != url):
+        broken["checked_url"] = url  # Only include if different from original
+    broken_links.append(broken)
 
-def test_value(link, depth=0):
+def test_value(link, depth=0, origin_url=None, origin_file=None):
     """
     Checks if the url key is an object or not. If it is, iterate through every link in the object
     and check the URL for expected responses by calling check_url(link, url). If check fails, the
     entire object (with just the broken link) will be written to broken_links.json by the
-    copy_and_write_broken_link(link, url) function.
+    record_broken_link(link, url, error, origin_url, origin_file) function.
 
     Args: 
         link (dictionary): dictionary object containing key value pairs ('url': 'www.theurl.com')
                             that need to be tested.
+        depth (int): number of redirections a link has caused
+        origin_url (str, optional): The original URL from the source data.
+        origin_file (str, optional): The original file from the source data.
 
     Returns: 
         None, outputs to console, writes to redirected_links.txt or broken_links.json
     """
     if depth > 3:
-        print(f"Max recursion depth reached for link: {link}")
-        link['Error'] = "Max recursion depth reached for link."
-
-        url_value = link['url']
-        copy_and_write_broken_link(link, url_value)
+        print(f"Max recursion depth reached for link: {origin_url or link.get('url')}")
+        broken = {
+            "file": origin_file or link.get("file"),
+            "url": origin_url or link.get("url"),
+            "Error": "Max recursion depth reached for link."
+        }
+        broken_links.append(broken)
         return
+    
+    # Set origin_url and origin_file if not already set
+    if origin_url is None:
+        origin_url = link.get("url")
+    if origin_file is None:
+        origin_file = link.get("file")
+
     try:
         url_value = link['url']
         if isinstance(url_value, dict):
             for lang, url in url_value.items():
-                check_url(link, url, depth)
+                check_url(link, url, depth, origin_url, origin_file)
         else:
-            check_url(link, url_value, depth)
+            check_url(link, url_value, depth, origin_url, origin_file)
     except requests.RequestException as e:
         print(f"{type(e)} -> Error while checking URL {link['url']}: {e}\n")
-        link['Error'] = str(e)
-        copy_and_write_broken_link(link, url)
+        record_broken_link(link, url, str(e), origin_url, origin_file)
 
-def check_url(link, url, depth=0):
+def check_url(link, url, depth=0, origin_url=None, origin_file=None):
     """
     Tests an individual link for a valid HTTP response (not 404 or other Error). 
     Redirection chains are logged in redirected_links.txt.
@@ -106,6 +120,9 @@ def check_url(link, url, depth=0):
         link (dictionary): dictionary object containing key value pairs ('url': 'www.theurl.com')
             that need to be tested.
         url (dictionary, string): The url string to be tested for a valid response.
+        depth (int): number of redirections a link has caused
+        origin_url (str, optional): The original URL from the source data.
+        origin_file (str, optional): The original file from the source data.
 
     Returns: 
         None, outputs to console, writes to redirected_links.txt or broken_links.json
@@ -139,9 +156,7 @@ def check_url(link, url, depth=0):
                         redirected_links.append(url + " Redirected to: " + response.url) #redirection chain ended
                     elif response.status_code == 404:
                         # If 404, add to the broken_links list
-                        print(f"Broken link: {url}\n")
-                        link['Error'] = '404 Status Code'
-                        copy_and_write_broken_link(link, url)
+                        record_broken_link(link, url, '404 Status Code', origin_url, origin_file)
                     else:
                         print(f"Ended with status {response.status_code} at {response.url}\n")
                 else:
@@ -149,12 +164,10 @@ def check_url(link, url, depth=0):
 
     except requests.ConnectionError as e:
         print(f"Connection error while checking URL {url}. Treating as 404. ERROR: {e}\n")
-        link['Error'] = str(e)
-        copy_and_write_broken_link(link, url)
+        record_broken_link(link, url, str(e), origin_url, origin_file)
     except requests.Timeout as e:
         print(f"Timeout for URL {url}. Treating as 404. ERROR: {e}\n")
-        link['Error'] = str(e)
-        copy_and_write_broken_link(link, url)
+        record_broken_link(link, url, str(e), origin_url, origin_file)
     except requests.exceptions.MissingSchema as e:
         print(f"Missing Schema: {url}. ERROR: {e}\n")
         
@@ -164,7 +177,7 @@ def check_url(link, url, depth=0):
             missing_path = match.group(1)
             new_URL = "https://" + domain + missing_path
             print(f"The new URL is: {new_URL}\n")
-            test_value({"url": new_URL}, depth = depth + 1)  # Pass as a dictionary with the new URL for testing
+            test_value({"url": new_URL}, depth = depth + 1, origin_url=origin_url, origin_file=origin_file)  # Pass as a dictionary with the new URL for testing
         else:
             print("Could not extract missing path from the error message.") 
     

--- a/broken-link-check.py
+++ b/broken-link-check.py
@@ -63,7 +63,7 @@ def copy_and_write_broken_link(link, url):
     else:
         broken_links.append(link)
 
-def test_link(link, depth=0):
+def test_value(link, depth=0):
     """
     Checks if the url key is an object or not. If it is, iterate through every link in the object
     and check the URL for expected responses by calling check_url(link, url). If check fails, the
@@ -164,7 +164,7 @@ def check_url(link, url, depth=0):
             missing_path = match.group(1)
             new_URL = "https://" + domain + missing_path
             print(f"The new URL is: {new_URL}\n")
-            test_link({"url": new_URL}, depth = depth + 1)  # Pass as a dictionary with the new URL for testing
+            test_value({"url": new_URL}, depth = depth + 1)  # Pass as a dictionary with the new URL for testing
         else:
             print("Could not extract missing path from the error message.") 
     
@@ -189,7 +189,7 @@ try:
 
     # Loop through each link in the JSON
     for link in data[array_name]:
-        test_link(link)
+        test_value(link)
 
     # Print or save the broken links as needed
     with open('broken_links.json', 'w') as f:


### PR DESCRIPTION
Fixed error when websites redirect you more times than the requests module can handle. Also, ensured information such as the file name and original link is not lost when a redirection chain fails.